### PR TITLE
Fixes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -420,7 +420,7 @@ sink {
       ducklake {
         catalog-type = "sqlite"  # "duckdb", "sqlite", or "postgres"
         catalog-type = ${?RUUVI_DUCKDB_DUCKLAKE_CATALOG_TYPE}
-        catalog-path = "data/catalog.sqlite"
+        catalog-path = "data/ruuvidb.sqlite"
         catalog-path = ${?RUUVI_DUCKDB_DUCKLAKE_CATALOG_PATH}
         data-path = "data/ducklake_files/"
         data-path = ${?RUUVI_DUCKDB_DUCKLAKE_DATA_PATH}

--- a/Makefile
+++ b/Makefile
@@ -156,7 +156,7 @@ test-ducklake-sink: check-assembly create-test-data
 		if [ -d data/test_ducklake_files ]; then \
 			echo "✓ Data directory created: data/test_ducklake_files/" ; \
 			echo "Verifying data with DuckDB client..." ; \
-			ROW_COUNT=$$(duckdb :memory: -c "INSTALL ducklake; LOAD ducklake; ATTACH 'ducklake:sqlite:data/test_catalog.sqlite' AS my_ducklake (DATA_PATH 'data/test_ducklake_files/'); SELECT COUNT(*) FROM my_ducklake.telemetry;" | grep -E '^│[[:space:]]*[0-9]+' | grep -oE '[0-9]+' | head -1) ; \
+			ROW_COUNT=$$(duckdb :memory: -c "INSTALL ducklake; LOAD ducklake; ATTACH 'ducklake:sqlite:$(CURDIR)/data/test_catalog.sqlite' AS my_ducklake (DATA_PATH '$(CURDIR)/data/test_ducklake_files/'); SELECT COUNT(*) FROM my_ducklake.telemetry;" | grep -E '^│[[:space:]]*[0-9]+' | grep -oE '[0-9]+' | head -1) ; \
 			if [ "$$ROW_COUNT" = "2" ]; then \
 				echo "✓ Data verified: $$ROW_COUNT rows found in telemetry table" ; \
 			else \

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A Scala 3 + ZIO-based middleware for processing and forwarding Ruuvi Tag sensor 
 
 ### Features
 
-- ✅ **Multiple Sinks**: Console (stdout), JSON Lines (file), DuckDB (database), and HTTP (ruuvitag-api) sinks
+- ✅ **Multiple Sinks**: Console (stdout), JSON Lines (file), DuckDB (database), DuckLake (lakehouse), and HTTP (ruuvitag-api) sinks
 - ✅ **Configuration**: Type-safe config with HOCON + environment variable overrides
 - ✅ **Structured Logging**: ZIO logging with SLF4J/Logback backend
 - ✅ **Stream Processing**: ZIO Streams with backpressure support
@@ -32,6 +32,9 @@ make test-jsonlines-sink
 
 # Test DuckDB sink
 make test-duckdb-sink
+
+# Test DuckLake sink
+make test-ducklake-sink
 ```
 
 ### Available Sinks
@@ -126,6 +129,60 @@ SELECT * FROM telemetry WHERE mac_address = 'D5:12:34:66:14:14';
 - Timestamps are stored as milliseconds since epoch
 - All sensor values stored as integers for precision
 
+#### 3b. DuckLake Sink (Lakehouse Mode)
+
+An extension of the DuckDB sink that writes telemetry as Parquet files managed by a DuckLake catalog. Suitable for multi-client or distributed scenarios where concurrent readers and writers are needed.
+
+**Features:**
+- Stores data as Parquet files for efficient columnar analytics
+- Supports three catalog backends: DuckDB (single-client), SQLite (multi-client), PostgreSQL (distributed)
+- Creates catalog and data directories automatically
+- Appends to existing data (doesn't overwrite)
+- Inherits batch size and latency settings from DuckDB sink configuration
+
+**Configuration:**
+```shell
+# Minimal: enable DuckLake with default SQLite catalog
+export RUUVI_SINK_TYPE=duckdb
+export RUUVI_DUCKDB_DUCKLAKE_ENABLED=true
+
+# Full options
+export RUUVI_DUCKDB_DUCKLAKE_CATALOG_TYPE=sqlite        # "duckdb", "sqlite", or "postgres"
+export RUUVI_DUCKDB_DUCKLAKE_CATALOG_PATH=data/ruuvidb.sqlite  # catalog file (or PG connection string)
+export RUUVI_DUCKDB_DUCKLAKE_DATA_PATH=data/ducklake_files/    # directory for Parquet data files
+
+# Run
+java -jar target/scala-3.7.3/ruuvi-data-forwarder-assembly-0.1.0-SNAPSHOT.jar
+```
+
+**Catalog type comparison:**
+
+| Catalog type | Use case |
+|---|---|
+| `duckdb` | Single process, fastest local writes |
+| `sqlite` | Multiple local processes (default) |
+| `postgres` | Multi-host / distributed environments |
+
+**Inline examples:**
+```shell
+# SQLite catalog (default)
+RUUVI_SINK_TYPE=duckdb RUUVI_DUCKDB_DUCKLAKE_ENABLED=true \
+  java -jar target/scala-3.7.3/ruuvi-data-forwarder-assembly-0.1.0-SNAPSHOT.jar
+
+# DuckDB catalog
+RUUVI_SINK_TYPE=duckdb RUUVI_DUCKDB_DUCKLAKE_ENABLED=true \
+  RUUVI_DUCKDB_DUCKLAKE_CATALOG_TYPE=duckdb \
+  RUUVI_DUCKDB_DUCKLAKE_CATALOG_PATH=data/catalog.ducklake \
+  java -jar target/scala-3.7.3/ruuvi-data-forwarder-assembly-0.1.0-SNAPSHOT.jar
+
+# PostgreSQL catalog
+RUUVI_SINK_TYPE=duckdb RUUVI_DUCKDB_DUCKLAKE_ENABLED=true \
+  RUUVI_DUCKDB_DUCKLAKE_CATALOG_TYPE=postgres \
+  RUUVI_DUCKDB_DUCKLAKE_CATALOG_PATH="dbname=ruuvi_catalog host=localhost user=postgres" \
+  RUUVI_DUCKDB_DUCKLAKE_DATA_PATH=/shared/ruuvi/data/ \
+  java -jar target/scala-3.7.3/ruuvi-data-forwarder-assembly-0.1.0-SNAPSHOT.jar
+```
+
 #### 4. HTTP Sink
 
 Sends telemetry data to a ruuvitag-api compatible HTTP endpoint. Each RuuviTelemetry record is transformed into multiple measurements (temperature, humidity, pressure, battery, etc.) and posted to the API.
@@ -207,6 +264,17 @@ sink {
       path = "data/telemetry.db"       # Database file path (use ":memory:" for in-memory)
       table-name = "telemetry"         # Table name for storing telemetry
       debug-logging = true              # Log each telemetry to debug level
+      desired-batch-size = 5           # Records per batch before flush
+      desired-max-batch-latency-seconds = 30  # Max seconds before flushing batch
+
+      # DuckLake mode (lakehouse format using Parquet files)
+      ducklake-enabled = false
+
+      ducklake {
+        catalog-type = "sqlite"        # "duckdb", "sqlite", or "postgres"
+        catalog-path = "data/ruuvidb.sqlite"   # catalog file or PG connection string
+        data-path = "data/ducklake_files/"     # directory for Parquet data files
+      }
     }
 
     http {
@@ -226,6 +294,12 @@ sink {
 - `RUUVI_DUCKDB_PATH` - Database file path for DuckDB sink (use `:memory:` for in-memory)
 - `RUUVI_DUCKDB_TABLE_NAME` - Table name for DuckDB sink
 - `RUUVI_DUCKDB_DEBUG_LOGGING` - Enable/disable debug logging (`true`/`false`)
+- `RUUVI_DUCKDB_DESIRED_BATCH_SIZE` - Number of records per batch before flush
+- `RUUVI_DUCKDB_DESIRED_MAX_BATCH_LATENCY_SECONDS` - Max seconds before flushing a batch
+- `RUUVI_DUCKDB_DUCKLAKE_ENABLED` - Enable DuckLake (lakehouse) mode (`true`/`false`)
+- `RUUVI_DUCKDB_DUCKLAKE_CATALOG_TYPE` - Catalog backend: `duckdb`, `sqlite`, or `postgres`
+- `RUUVI_DUCKDB_DUCKLAKE_CATALOG_PATH` - Path to catalog file, or PostgreSQL connection string
+- `RUUVI_DUCKDB_DUCKLAKE_DATA_PATH` - Directory for Parquet data files
 - `RUUVI_HTTP_API_URL` - Base URL for ruuvitag-api HTTP sink
 - `RUUVI_HTTP_SENSOR_NAME` - Sensor name for HTTP sink API requests
 - `RUUVI_HTTP_DEBUG_LOGGING` - Enable/disable debug logging for HTTP sink (`true`/`false`)
@@ -285,6 +359,9 @@ make test-jsonlines-sink
 # Test DuckDB sink (database output)
 make test-duckdb-sink
 
+# Test DuckLake sink (lakehouse output)
+make test-ducklake-sink
+
 # Test all sinks
 make test-sinks
 ```
@@ -304,6 +381,10 @@ ruuvi-reader-rs | RUUVI_SINK_TYPE=jsonlines java -jar target/scala-3.7.3/ruuvi-d
 # Save to DuckDB database
 ruuvi-reader-rs | RUUVI_SINK_TYPE=duckdb java -jar target/scala-3.7.3/ruuvi-data-forwarder-assembly-0.1.0-SNAPSHOT.jar
 # Data saved to: data/telemetry.db
+
+# Save to DuckLake (lakehouse, SQLite catalog by default)
+ruuvi-reader-rs | RUUVI_SINK_TYPE=duckdb RUUVI_DUCKDB_DUCKLAKE_ENABLED=true java -jar target/scala-3.7.3/ruuvi-data-forwarder-assembly-0.1.0-SNAPSHOT.jar
+# Catalog: data/ruuvidb.sqlite  Data: data/ducklake_files/
 
 # Send to HTTP API
 ruuvi-reader-rs | RUUVI_SINK_TYPE=http RUUVI_HTTP_API_URL=http://api.example.com RUUVI_HTTP_SENSOR_NAME=outdoor-sensor java -jar target/scala-3.7.3/ruuvi-data-forwarder-assembly-0.1.0-SNAPSHOT.jar
@@ -326,6 +407,14 @@ cat telemetry.jsonl | \
   RUUVI_SINK_TYPE=duckdb \
   RUUVI_DUCKDB_PATH=/var/data/sensor.db \
   RUUVI_DUCKDB_TABLE_NAME=ruuvi_data \
+  java -jar target/scala-3.7.3/ruuvi-data-forwarder-assembly-0.1.0-SNAPSHOT.jar
+
+# DuckLake sink with custom catalog and data paths
+cat telemetry.jsonl | \
+  RUUVI_SINK_TYPE=duckdb \
+  RUUVI_DUCKDB_DUCKLAKE_ENABLED=true \
+  RUUVI_DUCKDB_DUCKLAKE_CATALOG_PATH=/var/data/catalog.sqlite \
+  RUUVI_DUCKDB_DUCKLAKE_DATA_PATH=/var/data/ducklake_files/ \
   java -jar target/scala-3.7.3/ruuvi-data-forwarder-assembly-0.1.0-SNAPSHOT.jar
 
 # HTTP sink with custom API
@@ -378,7 +467,9 @@ ruuvi-data-forwarder/
 │   ├── sinks/                              # Sink implementations
 │   │   ├── SensorValuesSink.scala         # Sink trait
 │   │   ├── ConsoleSensorValuesSink.scala  # Console sink
-│   │   └── JsonLinesSensorValuesSink.scala # JSON Lines sink
+│   │   ├── JsonLinesSensorValuesSink.scala # JSON Lines sink
+│   │   ├── DuckDBSensorValuesSink.scala   # DuckDB / DuckLake sink
+│   │   └── HttpSensorValuesSink.scala     # HTTP sink
 │   └── sources/                            # Source implementations
 │       ├── SensorValuesSource.scala
 │       └── ConsoleSensorValuesSource.scala
@@ -387,7 +478,9 @@ ruuvi-data-forwarder/
 │   └── logback.xml                         # Logging configuration
 ├── src/test/scala/
 │   ├── AppSpec.scala
-│   └── sinks/JsonLinesSensorValuesSinkSpec.scala
+│   └── sinks/
+│       ├── JsonLinesSensorValuesSinkSpec.scala
+│       └── DuckDBSensorValuesSinkSpec.scala
 ├── data/                                   # Default output directory
 ├── build.sbt                               # Build configuration
 └── Makefile                                # Build & test commands

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -57,7 +57,7 @@ sink {
 
       # Path to the catalog database file
       # Can be overridden with RUUVI_DUCKDB_DUCKLAKE_CATALOG_PATH env variable
-      catalog-path = "data/catalog.sqlite"
+      catalog-path = "data/ruuvidb.sqlite"
       catalog-path = ${?RUUVI_DUCKDB_DUCKLAKE_CATALOG_PATH}
 
       # Path to the directory where parquet data files will be stored

--- a/src/main/scala/sinks/DuckDBSensorValuesSink.scala
+++ b/src/main/scala/sinks/DuckDBSensorValuesSink.scala
@@ -232,7 +232,10 @@ class DuckDBSensorValuesSink(
         conn.commit()
       catch
         case e: Exception =>
-          conn.rollback()
+          try conn.rollback()
+          catch
+            case rollbackEx: Exception =>
+              e.addSuppressed(rollbackEx)
           throw e
       finally pstmt.close()
     }

--- a/src/main/scala/sinks/DuckDBSensorValuesSink.scala
+++ b/src/main/scala/sinks/DuckDBSensorValuesSink.scala
@@ -207,6 +207,9 @@ class DuckDBSensorValuesSink(
           mac_address
         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
       """
+      // Wrap batch execution in an explicit transaction so rollback always has
+      // an active transaction to target (fixes "cannot rollback - no transaction is active" error).
+      conn.setAutoCommit(false)
       val pstmt = conn.prepareStatement(insertSQL)
       try
         telemetryBatch.foreach { telemetry =>
@@ -226,5 +229,10 @@ class DuckDBSensorValuesSink(
           pstmt.addBatch()
         }
         pstmt.executeBatch()
+        conn.commit()
+      catch
+        case e: Exception =>
+          conn.rollback()
+          throw e
       finally pstmt.close()
     }

--- a/src/main/scala/sinks/DuckDBSensorValuesSink.scala
+++ b/src/main/scala/sinks/DuckDBSensorValuesSink.scala
@@ -81,13 +81,17 @@ class DuckDBSensorValuesSink(
           // DuckLake mode: connect via DuckLake extension
           ducklakeConfig match
             case Some(config) =>
-              // Create parent directories for catalog and data paths
-              val catalogFilePath = Paths.get(config.catalogPath)
+              // Resolve catalog and data paths to absolute paths so the path
+              // stored in the DuckLake catalog metadata is portable regardless
+              // of which working directory opens the catalog later.
+              val catalogFilePath = Paths.get(config.catalogPath).toAbsolutePath
               Option(catalogFilePath.getParent)
                 .foreach(Files.createDirectories(_))
+              val absCatalogPath = catalogFilePath.toString
 
-              val dataFilePath = Paths.get(config.dataPath)
+              val dataFilePath = Paths.get(config.dataPath).toAbsolutePath
               Files.createDirectories(dataFilePath)
+              val absDataPath = dataFilePath.toString
 
               // Create a regular DuckDB connection first
               val conn = DriverManager.getConnection("jdbc:duckdb:")
@@ -113,11 +117,11 @@ class DuckDBSensorValuesSink(
               // Attach DuckLake database with alias "ducklake"
               val attachSQL = config.catalogType match
                 case CatalogType.DuckDB =>
-                  s"ATTACH 'ducklake:${config.catalogPath}' AS ducklake (DATA_PATH '${config.dataPath}')"
+                  s"ATTACH 'ducklake:$absCatalogPath' AS ducklake (DATA_PATH '$absDataPath')"
                 case CatalogType.SQLite =>
-                  s"ATTACH 'ducklake:sqlite:${config.catalogPath}' AS ducklake (DATA_PATH '${config.dataPath}')"
+                  s"ATTACH 'ducklake:sqlite:$absCatalogPath' AS ducklake (DATA_PATH '$absDataPath')"
                 case CatalogType.Postgres =>
-                  s"ATTACH 'ducklake:${config.catalogPath}' AS ducklake (DATA_PATH '${config.dataPath}')"
+                  s"ATTACH 'ducklake:$absCatalogPath' AS ducklake (DATA_PATH '$absDataPath')"
 
               val attachStmt = conn.createStatement()
               try attachStmt.execute(attachSQL)

--- a/src/test/scala/sinks/DuckDBSensorValuesSinkSpec.scala
+++ b/src/test/scala/sinks/DuckDBSensorValuesSinkSpec.scala
@@ -910,7 +910,7 @@ object DuckDBSensorValuesSinkSpec extends ZIOSpecDefault:
       val ducklakeConfig = DuckLakeConfig(
         catalogType = CatalogType.DuckDB,
         catalogPath = relativeCatalogPath, // relative path
-        dataPath = relativeDataPath        // relative path
+        dataPath = relativeDataPath // relative path
       )
 
       val sink = DuckDBSensorValuesSink(

--- a/src/test/scala/sinks/DuckDBSensorValuesSinkSpec.scala
+++ b/src/test/scala/sinks/DuckDBSensorValuesSinkSpec.scala
@@ -877,5 +877,104 @@ object DuckDBSensorValuesSinkSpec extends ZIOSpecDefault:
       yield count
 
       assertZIO(writeAndRead)(Assertion.equalTo(2))
+    },
+    test(
+      "DuckDBSensorValuesSink with DuckLake should resolve relative paths to absolute"
+    ) {
+      // Use paths that are relative to the current working directory.
+      // The sink must convert them to absolute before building the ATTACH SQL so that
+      // the path baked into the DuckLake catalog metadata is portable across working dirs.
+      val uniqueId = java.util.UUID.randomUUID().toString
+      val relativeCatalogPath = s"test-ducklake-rel-catalog-$uniqueId.ducklake"
+      val relativeDataPath = s"test-ducklake-rel-data-$uniqueId"
+
+      // Pre-compute the expected absolute paths so we can verify the catalog and
+      // data directory are created there (not only at the relative locations).
+      val expectedAbsCatalogPath =
+        Paths.get(relativeCatalogPath).toAbsolutePath.toString
+      val expectedAbsDataPath =
+        Paths.get(relativeDataPath).toAbsolutePath.toString
+
+      val testTelemetry = RuuviTelemetry(
+        batteryPotential = 2335,
+        humidity = 653675,
+        macAddress = Seq(254, 38, 136, 122, 102, 102),
+        measurementTsMs = 1693460525699L,
+        measurementSequenceNumber = 53300,
+        movementCounter = 2,
+        pressure = 100755,
+        temperatureMillicelsius = -29020,
+        txPower = 4
+      )
+
+      val ducklakeConfig = DuckLakeConfig(
+        catalogType = CatalogType.DuckDB,
+        catalogPath = relativeCatalogPath, // relative path
+        dataPath = relativeDataPath        // relative path
+      )
+
+      val sink = DuckDBSensorValuesSink(
+        dbPath = "",
+        tableName = "telemetry",
+        debugLogging = false,
+        desiredBatchSize = 5,
+        desiredMaxBatchLatencySeconds = 30,
+        ducklakeEnabled = true,
+        ducklakeConfig = Some(ducklakeConfig)
+      )
+
+      val writeAndVerify = for
+        _ <- ZStream
+          .fromIterable(List(testTelemetry))
+          .groupedWithin(
+            sink.desiredBatchSize,
+            zio.Duration.fromSeconds(sink.desiredMaxBatchLatencySeconds.toLong)
+          )
+          .run(sink.make)
+
+        // Verify the catalog was created at the absolute path and that we can
+        // read data back from it using absolute paths, confirming the sink stored
+        // absolute paths in the catalog metadata rather than relative ones.
+        count <- ZIO.attemptBlocking {
+          Class.forName("org.duckdb.DuckDBDriver")
+          val conn = DriverManager.getConnection("jdbc:duckdb:")
+
+          val installStmt = conn.createStatement()
+          installStmt.execute("INSTALL ducklake")
+          installStmt.execute("LOAD ducklake")
+          installStmt.close()
+
+          val attachStmt = conn.createStatement()
+          attachStmt.execute(
+            s"ATTACH 'ducklake:$expectedAbsCatalogPath' AS ducklake (DATA_PATH '$expectedAbsDataPath')"
+          )
+          attachStmt.close()
+
+          val stmt = conn.createStatement()
+          val rs = stmt.executeQuery(
+            "SELECT COUNT(*) as count FROM ducklake.telemetry"
+          )
+          rs.next()
+          val result = rs.getInt("count")
+          rs.close()
+          stmt.close()
+          conn.close()
+          result
+        }
+
+        // Clean up
+        _ <- ZIO.attempt {
+          val catalogFile = Paths.get(expectedAbsCatalogPath)
+          Files.deleteIfExists(catalogFile)
+          val dataDir = Paths.get(expectedAbsDataPath)
+          if Files.exists(dataDir) then
+            Files
+              .walk(dataDir)
+              .sorted(java.util.Comparator.reverseOrder())
+              .forEach(Files.deleteIfExists(_))
+        }
+      yield count
+
+      assertZIO(writeAndVerify)(Assertion.equalTo(1))
     }
   )


### PR DESCRIPTION
[fix: resolve DuckLake catalog and data paths to absolute before ATTACH](https://github.com/tkasu/ruuvi-data-forwarder/commit/a4ffcb2c848a91097c0700283b4b4151e6c4e9e5)

Relative paths baked into ducklake_metadata.data_path caused
TableNotFound / file-not-found errors when any process opened the
catalog from a different working directory (e.g. ruuvi-ducklake-mcp).
Calling .toAbsolutePath on both paths before building the ATTACH SQL
makes the catalog self-contained and portable.

[fix: wrap DuckDB batch inserts in explicit transaction and use absolu…](https://github.com/tkasu/ruuvi-data-forwarder/commit/f468083f02b627a67c98e16afc02cb5d04c13504)

…te paths for DuckLake

- Wrap batch insert in setAutoCommit(false)/commit/rollback to avoid
  'cannot rollback - no transaction is active' errors on batch failure
- Rename default DuckLake catalog path from catalog.sqlite to ruuvidb.sqlite
- Fix Makefile DuckLake integration test to use absolute paths when
  re-attaching catalog so DATA_PATH matches what the catalog stored

Co-authored-by: Claude <claude@anthropic.com>