### PR TITLE
feat: Add scheduled DuckLake maintenance with configurable CHECKPOINT + change default catalog path

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -57,13 +57,32 @@ sink {
 
       # Path to the catalog database file
       # Can be overridden with RUUVI_DUCKDB_DUCKLAKE_CATALOG_PATH env variable
-      catalog-path = "data/catalog.sqlite"
+      catalog-path = "data/ruuvidb.sqlite"
       catalog-path = ${?RUUVI_DUCKDB_DUCKLAKE_CATALOG_PATH}
 
       # Path to the directory where parquet data files will be stored
       # Can be overridden with RUUVI_DUCKDB_DUCKLAKE_DATA_PATH env variable
       data-path = "data/ducklake_files/"
       data-path = ${?RUUVI_DUCKDB_DUCKLAKE_DATA_PATH}
+
+      # Maintenance configuration for periodic DuckLake CHECKPOINT operations
+      maintenance {
+        # Enable scheduled maintenance (CHECKPOINT) for DuckLake
+        # Can be overridden with RUUVI_DUCKDB_DUCKLAKE_MAINTENANCE_ENABLED env variable
+        enabled = false
+        enabled = ${?RUUVI_DUCKDB_DUCKLAKE_MAINTENANCE_ENABLED}
+
+        # Interval in seconds between maintenance runs
+        # Can be overridden with RUUVI_DUCKDB_DUCKLAKE_MAINTENANCE_INTERVAL_SECONDS env variable
+        interval-seconds = 3600
+        interval-seconds = ${?RUUVI_DUCKDB_DUCKLAKE_MAINTENANCE_INTERVAL_SECONDS}
+
+        # Expire snapshots older than this interval (DuckDB interval string, e.g. "1 week", "2 minutes", "168 hours")
+        # Passed directly to DuckLake's expire_older_than option during CHECKPOINT
+        # Can be overridden with RUUVI_DUCKDB_DUCKLAKE_MAINTENANCE_EXPIRE_OLDER_THAN env variable
+        expire-older-than = "1 week"
+        expire-older-than = ${?RUUVI_DUCKDB_DUCKLAKE_MAINTENANCE_EXPIRE_OLDER_THAN}
+      }
     }
   }
 

--- a/src/main/scala/App.scala
+++ b/src/main/scala/App.scala
@@ -106,12 +106,26 @@ object App extends ZIOAppDefault:
                         s"Catalog type: ${dlConfig.catalogType}"
                       ) *>
                       ZIO.logInfo(s"Catalog path: ${dlConfig.catalogPath}") *>
-                      ZIO.logInfo(s"Data path: ${dlConfig.dataPath}")
+                      ZIO.logInfo(s"Data path: ${dlConfig.dataPath}") *>
+                      ZIO.logInfo(
+                        s"Maintenance enabled: ${dlConfig.maintenance.enabled}"
+                      ) *>
+                      ZIO.logInfo(
+                        s"Maintenance interval: ${dlConfig.maintenance.intervalSeconds}s"
+                      )
                   case None =>
                     ZIO.logWarning(
                       "DuckLake enabled but configuration is missing, falling back to standard DuckDB mode"
                     )
               else ZIO.logInfo("Using standard DuckDB mode")
+
+            val startMaintenance =
+              if duckdbConfig.ducklakeEnabled then
+                duckdbConfig.ducklake match
+                  case Some(dlConfig) =>
+                    DuckLakeMaintenance(dlConfig).startScheduler()
+                  case None => ZIO.unit
+              else ZIO.unit
 
             ZIO.logInfo(s"Using DuckDB sink: ${duckdbConfig.path}") *>
               ZIO.logInfo(s"Table name: ${duckdbConfig.tableName}") *>
@@ -125,6 +139,7 @@ object App extends ZIOAppDefault:
                 s"Batch latency: ${duckdbConfig.desiredMaxBatchLatencySeconds}s"
               ) *>
               logDuckLake *>
+              startMaintenance *>
               ZIO.succeed(
                 DuckDBSensorValuesSink(
                   duckdbConfig.path,

--- a/src/main/scala/config/SinkConfig.scala
+++ b/src/main/scala/config/SinkConfig.scala
@@ -48,13 +48,26 @@ object CatalogType:
         )
     }
 
+case class DuckLakeMaintenanceConfig(
+    enabled: Boolean,
+    @name("interval-seconds")
+    intervalSeconds: Int,
+    @name("expire-older-than")
+    expireOlderThan: String
+)
+
+object DuckLakeMaintenanceConfig:
+  val descriptor: Config[DuckLakeMaintenanceConfig] =
+    deriveConfig[DuckLakeMaintenanceConfig]
+
 case class DuckLakeConfig(
     @name("catalog-type")
     catalogType: CatalogType,
     @name("catalog-path")
     catalogPath: String,
     @name("data-path")
-    dataPath: String
+    dataPath: String,
+    maintenance: DuckLakeMaintenanceConfig
 )
 
 object DuckLakeConfig:

--- a/src/main/scala/sinks/DuckLakeMaintenance.scala
+++ b/src/main/scala/sinks/DuckLakeMaintenance.scala
@@ -1,0 +1,138 @@
+package sinks
+
+import config.{CatalogType, DuckLakeConfig}
+import zio.*
+import zio.logging.*
+import java.sql.{Connection, DriverManager}
+import java.nio.file.{Files, Paths}
+
+/** Handles scheduled DuckLake maintenance operations.
+  *
+  * Runs the DuckLake `CHECKPOINT` statement on a fixed schedule. `CHECKPOINT` bundles all
+  * maintenance functions in order:
+  *   1. `ducklake_flush_inlined_data`
+  *   2. `ducklake_expire_snapshots`
+  *   3. `ducklake_merge_adjacent_files`
+  *   4. `ducklake_rewrite_data_files`
+  *   5. `ducklake_cleanup_old_files`
+  *   6. `ducklake_delete_orphaned_files`
+  *
+  * Before running `CHECKPOINT`, the `expire_older_than` option is set on the catalog so that
+  * snapshot expiry and file cleanup use the configured retention window.
+  *
+  * This runs concurrently with the append pipeline — DuckLake snapshot isolation ensures
+  * there are no conflicts with ongoing inserts.
+  */
+class DuckLakeMaintenance(config: DuckLakeConfig):
+
+  private val maintenanceConfig = config.maintenance
+
+  /** Acquire a DuckLake JDBC connection with all necessary extensions loaded and
+    * the DuckLake catalog attached as "ducklake".
+    */
+  private def acquireConnection: ZIO[Scope, Throwable, Connection] =
+    ZIO.acquireRelease(
+      ZIO.attemptBlocking {
+        Class.forName("org.duckdb.DuckDBDriver")
+
+        val catalogFilePath = Paths.get(config.catalogPath)
+        Option(catalogFilePath.getParent)
+          .foreach(Files.createDirectories(_))
+
+        val dataFilePath = Paths.get(config.dataPath)
+        Files.createDirectories(dataFilePath)
+
+        val conn = DriverManager.getConnection("jdbc:duckdb:")
+
+        val installStmt = conn.createStatement()
+        try
+          installStmt.execute("INSTALL ducklake")
+          installStmt.execute("LOAD ducklake")
+
+          config.catalogType match
+            case CatalogType.SQLite =>
+              installStmt.execute("INSTALL sqlite")
+              installStmt.execute("LOAD sqlite")
+            case CatalogType.Postgres =>
+              installStmt.execute("INSTALL postgres")
+              installStmt.execute("LOAD postgres")
+            case CatalogType.DuckDB =>
+        finally installStmt.close()
+
+        val attachSQL = config.catalogType match
+          case CatalogType.DuckDB =>
+            s"ATTACH 'ducklake:${config.catalogPath}' AS ducklake (DATA_PATH '${config.dataPath}')"
+          case CatalogType.SQLite =>
+            s"ATTACH 'ducklake:sqlite:${config.catalogPath}' AS ducklake (DATA_PATH '${config.dataPath}')"
+          case CatalogType.Postgres =>
+            s"ATTACH 'ducklake:${config.catalogPath}' AS ducklake (DATA_PATH '${config.dataPath}')"
+
+        val attachStmt = conn.createStatement()
+        try attachStmt.execute(attachSQL)
+        finally attachStmt.close()
+
+        conn
+      }
+    )(conn => ZIO.attemptBlocking(conn.close()).orDie)
+
+  /** Run the full DuckLake maintenance sequence via the `CHECKPOINT` statement.
+    *
+    * Step 1: Set `expire_older_than` on the catalog so that snapshot expiry and file cleanup
+    *         respect the configured retention window.
+    * Step 2: Run `CHECKPOINT`, which DuckLake expands internally into all 6 maintenance
+    *         functions: `ducklake_flush_inlined_data`, `ducklake_expire_snapshots`,
+    *         `ducklake_merge_adjacent_files`, `ducklake_rewrite_data_files`,
+    *         `ducklake_cleanup_old_files`, `ducklake_delete_orphaned_files`.
+    *
+    * The connection is acquired and released within this call, keeping it safe
+    * to call concurrently with the insert pipeline.
+    */
+  val runCheckpoint: ZIO[Any, Throwable, Unit] =
+    ZIO.scoped {
+      for
+        _ <- ZIO.logInfo(
+          s"Starting DuckLake maintenance (expire_older_than='${maintenanceConfig.expireOlderThan}')"
+        )
+        conn <- acquireConnection
+        _ <- ZIO.attemptBlocking {
+          val stmt = conn.createStatement()
+          try
+            // Step 1: Configure the retention window for snapshot expiry and file cleanup
+            stmt.execute(
+              s"CALL ducklake.set_option('expire_older_than', '${maintenanceConfig.expireOlderThan}')"
+            )
+            // Step 2: Run all 6 maintenance operations in one statement
+            stmt.execute("CHECKPOINT")
+          finally stmt.close()
+        }
+        _ <- ZIO.logInfo("DuckLake maintenance completed successfully")
+      yield ()
+    }.tapError(err =>
+      ZIO.logError(s"DuckLake maintenance failed: ${err.getMessage}")
+    )
+
+  /** Start the maintenance scheduler as a daemon fiber.
+    *
+    * If maintenance is disabled, returns immediately without starting anything.
+    * Otherwise, forks a daemon fiber that runs the full maintenance sequence on
+    * a fixed schedule. The first run is delayed by one full interval so startup
+    * does not race with the sink's own catalog initialization. Errors in
+    * individual runs are logged and swallowed so a transient failure never kills
+    * the scheduler or the main pipeline.
+    */
+  def startScheduler(): ZIO[Any, Nothing, Unit] =
+    if !maintenanceConfig.enabled then
+      ZIO.logInfo("DuckLake maintenance scheduler is disabled")
+    else
+      ZIO.logInfo(
+        s"Starting DuckLake maintenance scheduler (interval=${maintenanceConfig.intervalSeconds}s, " +
+          s"expire_older_than='${maintenanceConfig.expireOlderThan}')"
+      ) *>
+        (ZIO.sleep(maintenanceConfig.intervalSeconds.seconds) *>
+          runCheckpoint.catchAll(err =>
+            ZIO.logError(
+              s"DuckLake maintenance run failed (will retry on next interval): ${err.getMessage}"
+            )
+          )).forever
+          .forkDaemon
+          .unit

--- a/src/main/scala/sinks/DuckLakeMaintenance.scala
+++ b/src/main/scala/sinks/DuckLakeMaintenance.scala
@@ -8,27 +8,25 @@ import java.nio.file.{Files, Paths}
 
 /** Handles scheduled DuckLake maintenance operations.
   *
-  * Runs the DuckLake `CHECKPOINT` statement on a fixed schedule. `CHECKPOINT` bundles all
-  * maintenance functions in order:
-  *   1. `ducklake_flush_inlined_data`
-  *   2. `ducklake_expire_snapshots`
-  *   3. `ducklake_merge_adjacent_files`
-  *   4. `ducklake_rewrite_data_files`
-  *   5. `ducklake_cleanup_old_files`
-  *   6. `ducklake_delete_orphaned_files`
+  * Runs the DuckLake `CHECKPOINT` statement on a fixed schedule. `CHECKPOINT`
+  * bundles all maintenance functions in order:
+  *   1. `ducklake_flush_inlined_data` 2. `ducklake_expire_snapshots` 3.
+  *      `ducklake_merge_adjacent_files` 4. `ducklake_rewrite_data_files` 5.
+  *      `ducklake_cleanup_old_files` 6. `ducklake_delete_orphaned_files`
   *
-  * Before running `CHECKPOINT`, the `expire_older_than` option is set on the catalog so that
-  * snapshot expiry and file cleanup use the configured retention window.
+  * Before running `CHECKPOINT`, the `expire_older_than` option is set on the
+  * catalog so that snapshot expiry and file cleanup use the configured
+  * retention window.
   *
-  * This runs concurrently with the append pipeline — DuckLake snapshot isolation ensures
-  * there are no conflicts with ongoing inserts.
+  * This runs concurrently with the append pipeline — DuckLake snapshot
+  * isolation ensures there are no conflicts with ongoing inserts.
   */
 class DuckLakeMaintenance(config: DuckLakeConfig):
 
   private val maintenanceConfig = config.maintenance
 
-  /** Acquire a DuckLake JDBC connection with all necessary extensions loaded and
-    * the DuckLake catalog attached as "ducklake".
+  /** Acquire a DuckLake JDBC connection with all necessary extensions loaded
+    * and the DuckLake catalog attached as "ducklake".
     */
   private def acquireConnection: ZIO[Scope, Throwable, Connection] =
     ZIO.acquireRelease(
@@ -77,39 +75,41 @@ class DuckLakeMaintenance(config: DuckLakeConfig):
 
   /** Run the full DuckLake maintenance sequence via the `CHECKPOINT` statement.
     *
-    * Step 1: Set `expire_older_than` on the catalog so that snapshot expiry and file cleanup
-    *         respect the configured retention window.
-    * Step 2: Run `CHECKPOINT`, which DuckLake expands internally into all 6 maintenance
-    *         functions: `ducklake_flush_inlined_data`, `ducklake_expire_snapshots`,
-    *         `ducklake_merge_adjacent_files`, `ducklake_rewrite_data_files`,
-    *         `ducklake_cleanup_old_files`, `ducklake_delete_orphaned_files`.
+    * Step 1: Set `expire_older_than` on the catalog so that snapshot expiry and
+    * file cleanup respect the configured retention window. Step 2: Run
+    * `CHECKPOINT`, which DuckLake expands internally into all 6 maintenance
+    * functions: `ducklake_flush_inlined_data`, `ducklake_expire_snapshots`,
+    * `ducklake_merge_adjacent_files`, `ducklake_rewrite_data_files`,
+    * `ducklake_cleanup_old_files`, `ducklake_delete_orphaned_files`.
     *
     * The connection is acquired and released within this call, keeping it safe
     * to call concurrently with the insert pipeline.
     */
   val runCheckpoint: ZIO[Any, Throwable, Unit] =
-    ZIO.scoped {
-      for
-        _ <- ZIO.logInfo(
-          s"Starting DuckLake maintenance (expire_older_than='${maintenanceConfig.expireOlderThan}')"
-        )
-        conn <- acquireConnection
-        _ <- ZIO.attemptBlocking {
-          val stmt = conn.createStatement()
-          try
-            // Step 1: Configure the retention window for snapshot expiry and file cleanup
-            stmt.execute(
-              s"CALL ducklake.set_option('expire_older_than', '${maintenanceConfig.expireOlderThan}')"
-            )
-            // Step 2: Run all 6 maintenance operations in one statement
-            stmt.execute("CHECKPOINT")
-          finally stmt.close()
-        }
-        _ <- ZIO.logInfo("DuckLake maintenance completed successfully")
-      yield ()
-    }.tapError(err =>
-      ZIO.logError(s"DuckLake maintenance failed: ${err.getMessage}")
-    )
+    ZIO
+      .scoped {
+        for
+          _ <- ZIO.logInfo(
+            s"Starting DuckLake maintenance (expire_older_than='${maintenanceConfig.expireOlderThan}')"
+          )
+          conn <- acquireConnection
+          _ <- ZIO.attemptBlocking {
+            val stmt = conn.createStatement()
+            try
+              // Step 1: Configure the retention window for snapshot expiry and file cleanup
+              stmt.execute(
+                s"CALL ducklake.set_option('expire_older_than', '${maintenanceConfig.expireOlderThan}')"
+              )
+              // Step 2: Run all 6 maintenance operations in one statement
+              stmt.execute("CHECKPOINT")
+            finally stmt.close()
+          }
+          _ <- ZIO.logInfo("DuckLake maintenance completed successfully")
+        yield ()
+      }
+      .tapError(err =>
+        ZIO.logError(s"DuckLake maintenance failed: ${err.getMessage}")
+      )
 
   /** Start the maintenance scheduler as a daemon fiber.
     *
@@ -117,8 +117,8 @@ class DuckLakeMaintenance(config: DuckLakeConfig):
     * Otherwise, forks a daemon fiber that runs the full maintenance sequence on
     * a fixed schedule. The first run is delayed by one full interval so startup
     * does not race with the sink's own catalog initialization. Errors in
-    * individual runs are logged and swallowed so a transient failure never kills
-    * the scheduler or the main pipeline.
+    * individual runs are logged and swallowed so a transient failure never
+    * kills the scheduler or the main pipeline.
     */
   def startScheduler(): ZIO[Any, Nothing, Unit] =
     if !maintenanceConfig.enabled then
@@ -133,6 +133,4 @@ class DuckLakeMaintenance(config: DuckLakeConfig):
             ZIO.logError(
               s"DuckLake maintenance run failed (will retry on next interval): ${err.getMessage}"
             )
-          )).forever
-          .forkDaemon
-          .unit
+          )).forever.forkDaemon.unit

--- a/src/test/scala/sinks/DuckDBSensorValuesSinkSpec.scala
+++ b/src/test/scala/sinks/DuckDBSensorValuesSinkSpec.scala
@@ -4,7 +4,7 @@ import zio.*
 import zio.test.*
 import zio.stream.*
 import dto.RuuviTelemetry
-import _root_.config.{DuckLakeConfig, CatalogType}
+import _root_.config.{DuckLakeConfig, CatalogType, DuckLakeMaintenanceConfig}
 import java.sql.{DriverManager, ResultSet}
 import java.nio.file.{Files, Paths}
 
@@ -688,7 +688,12 @@ object DuckDBSensorValuesSinkSpec extends ZIOSpecDefault:
       val ducklakeConfig = DuckLakeConfig(
         catalogType = CatalogType.DuckDB,
         catalogPath = tempCatalog.toString,
-        dataPath = tempDataDir.toString
+        dataPath = tempDataDir.toString,
+        maintenance = DuckLakeMaintenanceConfig(
+          enabled = false,
+          intervalSeconds = 3600,
+          expireOlderThan = "1 week"
+        )
       )
 
       val sink = DuckDBSensorValuesSink(
@@ -804,7 +809,12 @@ object DuckDBSensorValuesSinkSpec extends ZIOSpecDefault:
       val ducklakeConfig = DuckLakeConfig(
         catalogType = CatalogType.DuckDB,
         catalogPath = tempCatalog.toString,
-        dataPath = tempDataDir.toString
+        dataPath = tempDataDir.toString,
+        maintenance = DuckLakeMaintenanceConfig(
+          enabled = false,
+          intervalSeconds = 3600,
+          expireOlderThan = "1 week"
+        )
       )
 
       val sink = DuckDBSensorValuesSink(

--- a/src/test/scala/sinks/DuckLakeMaintenanceSpec.scala
+++ b/src/test/scala/sinks/DuckLakeMaintenanceSpec.scala
@@ -1,0 +1,181 @@
+package sinks
+
+import zio.*
+import zio.test.*
+import _root_.config.{CatalogType, DuckLakeConfig, DuckLakeMaintenanceConfig}
+import java.nio.file.{Files, Paths}
+
+object DuckLakeMaintenanceSpec extends ZIOSpecDefault:
+
+  /** Build a DuckLakeConfig backed by a DuckDB catalog stored at the given
+    * paths. Maintenance is always enabled with a very long interval so it
+    * does not fire automatically during tests.
+    */
+  private def makeConfig(
+      catalogPath: String,
+      dataPath: String,
+      maintenanceEnabled: Boolean = true,
+      expireOlderThan: String = "1 week"
+  ): DuckLakeConfig =
+    DuckLakeConfig(
+      catalogType = CatalogType.DuckDB,
+      catalogPath = catalogPath,
+      dataPath = dataPath,
+      maintenance = DuckLakeMaintenanceConfig(
+        enabled = maintenanceEnabled,
+        intervalSeconds = 9999,
+        expireOlderThan = expireOlderThan
+      )
+    )
+
+  /** Seed a DuckLake catalog+data directory with at least one insert so that
+    * the maintenance functions (merge, expire, cleanup) have something to work on.
+    */
+  private def seedDuckLake(
+      catalogPath: String,
+      dataPath: String
+  ): ZIO[Any, Throwable, Unit] =
+    ZIO.attemptBlocking {
+      Class.forName("org.duckdb.DuckDBDriver")
+      val conn =
+        java.sql.DriverManager.getConnection("jdbc:duckdb:")
+
+      val stmt = conn.createStatement()
+      try
+        stmt.execute("INSTALL ducklake")
+        stmt.execute("LOAD ducklake")
+        stmt.execute(
+          s"ATTACH 'ducklake:$catalogPath' AS ducklake (DATA_PATH '$dataPath')"
+        )
+        stmt.execute(
+          "CREATE TABLE IF NOT EXISTS ducklake.maint_test (id INTEGER NOT NULL)"
+        )
+        stmt.execute("INSERT INTO ducklake.maint_test VALUES (1)")
+      finally
+        stmt.close()
+        conn.close()
+    }
+
+  def spec = suite("DuckLakeMaintenanceSpec")(
+    test("runCheckpoint should complete successfully on a seeded DuckLake") {
+      val tempCatalog =
+        Files.createTempFile("ruuvi-maint-checkpoint-catalog-", ".ducklake")
+      val tempDataDir =
+        Files.createTempDirectory("ruuvi-maint-checkpoint-data-")
+      Files.deleteIfExists(tempCatalog)
+
+      val catalogPath = tempCatalog.toString
+      val dataPath = tempDataDir.toString
+
+      val run = for
+        _ <- seedDuckLake(catalogPath, dataPath)
+        config = makeConfig(catalogPath, dataPath)
+        maintenance = DuckLakeMaintenance(config)
+        _ <- maintenance.runCheckpoint
+        // Clean up
+        _ <- ZIO.attempt {
+          Files.deleteIfExists(tempCatalog)
+          Files
+            .walk(tempDataDir)
+            .sorted(java.util.Comparator.reverseOrder())
+            .forEach(Files.deleteIfExists(_))
+        }
+      yield true
+
+      assertZIO(run)(Assertion.isTrue)
+    },
+    test(
+      "runCheckpoint should succeed with a custom expire-older-than interval"
+    ) {
+      val tempCatalog =
+        Files.createTempFile("ruuvi-maint-expire-catalog-", ".ducklake")
+      val tempDataDir =
+        Files.createTempDirectory("ruuvi-maint-expire-data-")
+      Files.deleteIfExists(tempCatalog)
+
+      val catalogPath = tempCatalog.toString
+      val dataPath = tempDataDir.toString
+
+      val run = for
+        _ <- seedDuckLake(catalogPath, dataPath)
+        // Use a short expiry string to exercise the set_option path
+        config = makeConfig(catalogPath, dataPath, expireOlderThan = "2 minutes")
+        maintenance = DuckLakeMaintenance(config)
+        _ <- maintenance.runCheckpoint
+        _ <- ZIO.attempt {
+          Files.deleteIfExists(tempCatalog)
+          Files
+            .walk(tempDataDir)
+            .sorted(java.util.Comparator.reverseOrder())
+            .forEach(Files.deleteIfExists(_))
+        }
+      yield true
+
+      assertZIO(run)(Assertion.isTrue)
+    },
+    test(
+      "startScheduler should not start a fiber when maintenance is disabled"
+    ) {
+      val tempCatalog =
+        Files.createTempFile("ruuvi-maint-disabled-catalog-", ".ducklake")
+      val tempDataDir =
+        Files.createTempDirectory("ruuvi-maint-disabled-data-")
+      Files.deleteIfExists(tempCatalog)
+
+      val config = makeConfig(
+        tempCatalog.toString,
+        tempDataDir.toString,
+        maintenanceEnabled = false
+      )
+
+      // startScheduler() should complete immediately (returns ZIO.unit) without
+      // connecting to DuckLake or creating any files
+      val run = for
+        _ <- DuckLakeMaintenance(config).startScheduler()
+        // Catalog file should NOT have been created — scheduler is disabled
+        catalogCreated <- ZIO.attempt(Files.exists(tempCatalog))
+        _ <- ZIO.attempt {
+          Files.deleteIfExists(tempCatalog)
+          Files
+            .walk(tempDataDir)
+            .sorted(java.util.Comparator.reverseOrder())
+            .forEach(Files.deleteIfExists(_))
+        }
+      yield catalogCreated
+
+      assertZIO(run)(Assertion.isFalse)
+    },
+    test(
+      "startScheduler should fork a daemon fiber when maintenance is enabled"
+    ) {
+      val tempCatalog =
+        Files.createTempFile("ruuvi-maint-enabled-catalog-", ".ducklake")
+      val tempDataDir =
+        Files.createTempDirectory("ruuvi-maint-enabled-data-")
+      Files.deleteIfExists(tempCatalog)
+
+      val catalogPath = tempCatalog.toString
+      val dataPath = tempDataDir.toString
+
+      val run = for
+        _ <- seedDuckLake(catalogPath, dataPath)
+        config = makeConfig(catalogPath, dataPath)
+        maintenance = DuckLakeMaintenance(config)
+        // startScheduler() should return quickly after forking the daemon fiber.
+        // The first run is intentionally delayed by the full interval (9999s) so
+        // the fiber is sleeping and no maintenance work happens during this test.
+        _ <- maintenance.startScheduler()
+        // Give the daemon fiber a brief moment to be scheduled
+        _ <- ZIO.sleep(500.millis)
+        _ <- ZIO.attempt {
+          Files.deleteIfExists(tempCatalog)
+          Files
+            .walk(tempDataDir)
+            .sorted(java.util.Comparator.reverseOrder())
+            .forEach(Files.deleteIfExists(_))
+        }
+      yield true
+
+      assertZIO(run)(Assertion.isTrue)
+    }
+  ) @@ TestAspect.withLiveClock

--- a/src/test/scala/sinks/DuckLakeMaintenanceSpec.scala
+++ b/src/test/scala/sinks/DuckLakeMaintenanceSpec.scala
@@ -8,8 +8,8 @@ import java.nio.file.{Files, Paths}
 object DuckLakeMaintenanceSpec extends ZIOSpecDefault:
 
   /** Build a DuckLakeConfig backed by a DuckDB catalog stored at the given
-    * paths. Maintenance is always enabled with a very long interval so it
-    * does not fire automatically during tests.
+    * paths. Maintenance is always enabled with a very long interval so it does
+    * not fire automatically during tests.
     */
   private def makeConfig(
       catalogPath: String,
@@ -29,7 +29,8 @@ object DuckLakeMaintenanceSpec extends ZIOSpecDefault:
     )
 
   /** Seed a DuckLake catalog+data directory with at least one insert so that
-    * the maintenance functions (merge, expire, cleanup) have something to work on.
+    * the maintenance functions (merge, expire, cleanup) have something to work
+    * on.
     */
   private def seedDuckLake(
       catalogPath: String,
@@ -99,7 +100,11 @@ object DuckLakeMaintenanceSpec extends ZIOSpecDefault:
       val run = for
         _ <- seedDuckLake(catalogPath, dataPath)
         // Use a short expiry string to exercise the set_option path
-        config = makeConfig(catalogPath, dataPath, expireOlderThan = "2 minutes")
+        config = makeConfig(
+          catalogPath,
+          dataPath,
+          expireOlderThan = "2 minutes"
+        )
         maintenance = DuckLakeMaintenance(config)
         _ <- maintenance.runCheckpoint
         _ <- ZIO.attempt {


### PR DESCRIPTION
- [feat: Add scheduled DuckLake maintenance with configurable CHECKPOINT](https://github.com/tkasu/ruuvi-data-forwarder/commit/c7543d4c0532db57e42612f842029ee46200bd93)

Introduce DuckLakeMaintenance class that runs the DuckLake CHECKPOINT
statement (flush, expire snapshots, merge/rewrite files, cleanup) on a
configurable interval as a daemon fiber. Adds DuckLakeMaintenanceConfig
to SinkConfig and wires the scheduler into App.scala alongside the
existing DuckDB sink setup.

- [Change default DuckLake catalog filename to ruuvidb.sqlite](https://github.com/tkasu/ruuvi-data-forwarder/pull/22/commits/701e04270c60e932041ec154b963db65b265d454)